### PR TITLE
Feature/qwb 23/satnam

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -295,9 +295,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         // Should always end up with at least the principal product image
         $productPhotos = array();
-        foreach ($product->getMediaGalleryImages() as $image) {
-            $this->_logger->addDebug($image->getUrl());
-            array_push($productPhotos, $image->getUrl());
+        $images = $product->getMediaGalleryImages();
+        if (count($images) > 0) {
+            foreach ($product->getMediaGalleryImages() as $image) {
+                $this->_logger->addDebug($image->getUrl());
+                array_push($productPhotos, $image->getUrl());
+            }
         }
         $categoriesList = $this->getCategories($product);
 


### PR DESCRIPTION
Getting the categories of a product in Magento 2 is slightly different than Magento 1 but our architecture around it remains the same. Here is what the final product export looks like

```
{
  "title": "Antonia Racer Tank",
  "album_type": "product",
  "live_update": false,
  "num_photo": 0,
  "num_inbox_photo": 0,
  "product": {
    "name": "Antonia Racer Tank",
    "sku": "WT08",
    "buy_now_link_url": "http:\/\/magento.dev\/magentosecond\/antonia-racer-tank.html",
    "product_photo": "http:\/\/magento.dev\/magentosecond\/pub\/media\/catalog\/product\/w\/t\/wt08-black_main.jpg",
    "stock": 1500,
    "native_product_id": 1801,
    "variants_json": {
      "1786": {
        "variant_stock": 100,
        "variant_sku": "WT08-XS-Black"
      },
      "1787": {
        "variant_stock": 100,
        "variant_sku": "WT08-XS-Purple"
      },
      "1788": {
        "variant_stock": 100,
        "variant_sku": "WT08-XL-Yellow"
      }
    },
    "extra_fields": "{
      \"product_photos\": [
        
      ],
      \"categories\": [
        {
          \"category_id\": 26,
          \"category_name\": \"Bras & Tanks\"
        },
        {
          \"category_id\": 30,
          \"category_name\": \"Women Sale\"
        },
        {
          \"category_id\": 35,
          \"category_name\": \"Performance Fabrics\"
        },
        {
          \"category_id\": 2,
          \"category_name\": \"Default Category\"
        }
      ]
    }"
  }
}
```