### PR TITLE
Currencies

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -284,9 +284,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $pixlee = $this->_pixleeAPI;
 
         $extraFields = $this->getExtraFields($product);
+        $currencyCode = $this->_storeManager->getStore()->getCurrentCurrency()->getCode();
 
         $product_mediaurl = $this->_mediaConfig->getMediaUrl($product->getImage());
-        $response = $pixlee->createProduct($product->getName(), $product->getSku(), $product->getProductUrl(), $product_mediaurl, intval($product->getId()), $aggregateStock, $variantsDict, $extraFields);
+        $response = $pixlee->createProduct($product->getName(), $product->getSku(), $product->getProductUrl(), $product_mediaurl, intval($product->getId()), $aggregateStock, $variantsDict, $extraFields, $currencyCode);
         $this->_logger->addInfo("Product Exported to Pixlee");
         return $response;
     }

--- a/Helper/Pixlee.php
+++ b/Helper/Pixlee.php
@@ -27,7 +27,7 @@ class Pixlee
         return $this->getFromAPI("/albums");
     }
 
-    public function createProduct($product_name, $sku, $product_url , $product_image, $product_id = NULL, $aggregateStock = NULL, $variantsDict = NULL, $extraFields = NULL){
+    public function createProduct($product_name, $sku, $product_url , $product_image, $product_id = NULL, $aggregateStock = NULL, $variantsDict = NULL, $extraFields = NULL, $currencyCode) {
         $this->_logger->addDebug("* In createProduct");
         /*
             Converted from Rails API format to distillery API format
@@ -61,7 +61,7 @@ class Pixlee
         $product = array('name' => $product_name, 'sku' => $sku, 'buy_now_link_url' => $product_url,
             'product_photo' => $product_image, 'stock' => $aggregateStock,
             'native_product_id' => $product_id, 'variants_json' => $variantsDict,
-            'extra_fields' => $extraFields);
+            'extra_fields' => $extraFields, 'currency' => $currencyCode);
         $data = array('title' => $product_name, 'album_type' => 'product', 'live_update' => false, 'num_photo' => 0,
             'num_inbox_photo' => 0, 'product' => $product);
         $payload = $this->signedData($data);


### PR DESCRIPTION
1. The `_extractProduct($product)` method is used by both ATCs and Conversions for extracting product information. So adding currency here reflects in both ATCs and Conversions.
2. Conversions already have a `currency` field for the entire order. This is true for all our platforms.
3. For product exports, the currencies are added in a separate column and not in `extra_fields`.