### PR TITLE
variantsDict

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -222,7 +222,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         $this->_logger->addDebug("Product {$product->getId()} variantsDict: " . json_encode($variantsDict));
-        return $variantsDict;
+        if (empty($variantsDict)) {
+            return "{}";
+        } else {
+            return json_encode($variantsDict);
+        }
     }
 
     public function getCategories($product) {


### PR DESCRIPTION
### Context

I think the source of the issue was following.

```
$variableName = array();
echo json_encode($variableName); // prints []
```

Now I'm just returning a "{}" string if the variantsDict is empty. We need not worry about the fact that we were previously returning a php object and that now were returning a string. It was ultimately gonna be encoded anyways.