### PR TITLE
Bug/cr 2373/satnam

### DIFF
--- a/Helper/Pixlee.php
+++ b/Helper/Pixlee.php
@@ -148,7 +148,7 @@ class Pixlee
         //  Product updated.
         // Suppose we'll check the HTTP return code, but not expect a JSON 'status' field
         if( !$this->isBetween( $responseCode, 200, 299 ) ){
-            $this->_logger->addDebug("[Pixlee] :: HTTP $responseCode response from API. Not able to export/update product");
+            $this->_logger->addWarning("[Pixlee] :: HTTP $responseCode response from API. Not able to export/update product");
             return $theResult;
         } else {
             return $theResult;


### PR DESCRIPTION
Our Magento 2 extension is different from our Magento 1 extension in a few ways. One of the things is that we throw and catch a lot of exceptions so we have a decent architecture for that everywhere. In Magento 2, we do not have that architecture and this was the only non-admin panel place where we threw exceptions. I'm removing it since uncaught exceptions crash servers in PHP/magento