### PR TITLE
use the default method instead

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -386,7 +386,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $storeCurrency = $this->_storeManager->getStore($storeId)->getDefaultCurrency();
             $convertedPrice = $this->_storeManager->getStore($storeId)->getBaseCurrency()->convert($basePrice, $storeCurrency);
 
-            $productUrl = $storeBaseUrl . $storeProduct->getUrlKey() . ".html";
+            $productUrl = $storeProduct->getProductUrl();
 
             array_push($result, array(
                 'name' => $storeProduct->getName(),


### PR DESCRIPTION
There were two issues that I saw with product URLs
1. In the products table, sometimes the `buy_now_link_url` comes in as `https://<domain>/admin_qghs5a/catalog/product/view/id/15910/s/januscafe-teak-top-square-92-with-umbrella-hole-weather-teak/key/87c2b9a576c340cf900d22aca29414e7f0f28455bcc9b2265ba470b4f258c644/` instead of `https://<domain>/januscafe-teak-top-square-92-with-umbrella-hole-weather-teak.html` ... Unfortunately, all of my research indicates that the `getProductUrl` method without any extra params is the right method to call, but if the customers who a third party plugin to manage their URLs it might not return the correct URL 100% of the times and we will have to resort to `AccountHookJobs` to address such cases
2. In the product_regions, sometimes the `buy_now_link_url` comes in with an extra `.html` which was an easy fix. Also the latest Magento docs recommend to use the `getProductUrl` method whereever possible so its a good time to start using that instead.