### PR TITLE
check to make sure category id exists

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -304,9 +304,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $productCategories = $product->getCategoryIds();
 
         foreach ($productCategories as $categoryId) {
-            $parent_ids = $categoriesMap[$categoryId]['parent_ids'];
-            foreach ($parent_ids as $parent_id) {
-                array_push($allCategoriesIds, $parent_id);
+            // Check to make sure the category is in the categoriesMap before accessing
+            // This should always be the case, but there seems to be a bug causing
+            // Some Ids not to be found
+            $categoryInMap = isset($categoriesMap[$categoryId]);
+            if ($categoryInMap) {
+                $parent_ids = $categoriesMap[$categoryId]['parent_ids'];
+                foreach ($parent_ids as $parent_id) {
+                    array_push($allCategoriesIds, $parent_id);
+                }
             }
         }
 


### PR DESCRIPTION
A client brought up an issue where they got an out of bounds error when trying to access the categoriesMap array when defining category information for the product. The way the code is built, this should never happen (because all categories should be found in the array). But, until we can figure out why that happens, I've just added a check to make sure it exists before trying to access it.