### PR TITLE
update to version 1.6.2, change composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "pixlee/magento2",
+    "name": "pixlee-team/magento2",
     "description": "Social commerce platform to collect, curate, and display user-generated content to enhance your Magento store",
     "type": "magento2-module",
     "version": "1.2.1",
     "authors": [
         {
-            "name": "Pixlee",
+            "name": "Pixlee Team",
             "email": "magento@pixleeturnto.com",
             "homepage": "http://www.pixlee.com"
         }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pixlee-team/magento2",
     "description": "Social commerce platform to collect, curate, and display user-generated content to enhance your Magento store",
     "type": "magento2-module",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "authors": [
         {
             "name": "Pixlee Team",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Pixlee_Pixlee" setup_version="1.2.1" active="true"></module>
+    <module name="Pixlee_Pixlee" setup_version="1.2.2" active="true"></module>
 </config>


### PR DESCRIPTION
We're trying to get registered on packagist, but there's a namespace squatter who already took the "Pixlee" namespace, so this updates the composer package to belong to "pixlee-team"