### PR TITLE
Update product visibility to more useful values. Now excluding products only visible in search

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -178,7 +178,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getTotalProductsCount($websiteId)
     {
         $collection = $this->_catalogProduct->getCollection();
-        $collection->addFieldToFilter('visibility', ['neq' => 1]);
+        $collection->addFieldToFilter(
+            'visibility',
+            [
+                'in' =>
+                    [
+                        \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH,
+                        \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_CATALOG
+                    ]
+            ]
+        );
         $collection->addFieldToFilter('status', ['neq' => 2]);
         $collection->addWebsiteFilter($websiteId);
         $count = $collection->getSize();
@@ -188,7 +197,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getPaginatedProducts($limit, $offset, $websiteId)
     {
         $products = $this->_catalogProduct->getCollection();
-        $products->addFieldToFilter('visibility', ['neq' => 1]);
+        $products->addFieldToFilter(
+            'visibility',
+            [
+                'in' =>
+                    [
+                        \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH,
+                        \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_CATALOG
+                    ]
+            ]
+        );
         $products->addFieldToFilter('status', ['neq' => 2]);
         $products->addWebsiteFilter($websiteId);
         $products->getSelect()->limit($limit, $offset);
@@ -445,7 +463,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         // NOTE: 2016-03-21 - JUST noticed, that we were originally checking for getVisibility()
         // later on in the code, but since now I need $product to be reasonable in order to
-        if ($product->getVisibility() <= 1) {
+        if ($product->getVisibility() == \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE) {
             $this->_logger->addInfo("*** Product ID {$product->getId()} not visible in catalog, NOT EXPORTING");
             return;
         }


### PR DESCRIPTION
# Change Product Visibility Filter

## [MAINT-8436](https://pixlee.atlassian.net/browse/MAINT-8436)

### Intent or Business Objective
Amorepacific brought up that they were having issues sifting through all the products exported to Pixlee from their system. This change restricts the product export a little more to exclude products that are _only_ visible in search. Generally products only visible through search are not considered part of the regular catalog.
Often products only visible through search are variants being listed individually, but only in search, and they link to the regular PDP collected at the parent level.

### Technical Description
Change the visibility filter values from "not 1 (not visible)" to "2 (visible in the catalog) and 4 (visible in catalog and search)". This means that products with visibility 3 (visible in search) are no longer included.
Also changed the code to use constants defined in Magento, rather than the corresponding int value.

---

### Questions

#### Does this PR depend on any other changes?

- [ ] This pull request depends on other changes

##### If yes for above, Include links to the additional PR(s) below:

n/a

#### Have test cases been created?
- [ ] Test cases have been created

---

### Lessons learned? Questions for reviewers?
Nothing really

---

### Checklist When Creating PR

- [X] Tested locally - either manually via UI or via tests
- [ ] (N/A) Tests - if this is a bug fix, make sure a test is added to catch the bug going forward
- [ ] (N/A) Linting/Styling changes
- [ ] (N/A) Appropriate logging added to feature
- [ ] (N/A) Appropriate monitoring added to feature
- [X] Remove debug logging / redundant code / copy+paste stuff
- [ ] Squash and merge the changes to prod after approval
