### PR TITLE
Check existence of product image URL

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -476,14 +476,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         $productUrl = $this->getProductUrl($product, $websiteId);
-
+        $productImageUrl = $product->getImage() ? $this->_mediaConfig->getMediaUrl($product->getImage()) : '';
         $pixlee = $this->_pixleeAPI;
 
         $response = $pixlee->createProduct(
             $product->getName(),
             $product->getSku(),
             $productUrl,
-            $this->_mediaConfig->getMediaUrl($product->getImage()),
+            $productImageUrl,
             $this->_storeManager->getStore()->getCurrentCurrency()->getCode(),
             $product->getFinalPrice(),
             $this->getRegionalInformation($websiteId, $product),


### PR DESCRIPTION
# Check existence of product image URL

## MAINT-10797

Some products are being created without a product image URL. Deeper in the code, `str_replace` is being called on a value that is `NULL`. This is deprecated, so we should either switch it to an empty string or don't attempt to `str_replace` it at all.