### PR TITLE
TSD-320: Github Issues 84 & 85

### DIFF
--- a/Api/AnalyticsServiceInterface.php
+++ b/Api/AnalyticsServiceInterface.php
@@ -7,14 +7,17 @@ declare(strict_types=1);
 
 namespace Pixlee\Pixlee\Api;
 
+use Magento\Store\Api\Data\StoreInterface;
+
 interface AnalyticsServiceInterface
 {
     /**
-     * @param $event
-     * @param $payload
+     * @param String $event
+     * @param array $payload
+     * @param StoreInterface $store
      * @return mixed
      */
-    public function sendEvent($event, $payload);
+    public function sendEvent($event, $payload, $store);
 
     /**
      * @param $path

--- a/Model/Cart.php
+++ b/Model/Cart.php
@@ -158,7 +158,7 @@ class Cart
 
             $productData['variant_id']    = $actualProduct->getId();
             $productData['variant_sku']   = $actualProduct->getSku();
-            $productData['quantity']      = round($product->getQtyOrdered(), PHP_ROUND_HALF_UP);
+            $productData['quantity']      = round($product->getQtyOrdered());
             $productData['price']         = $this->pricingHelper->currency($actualProduct->getPrice(), true, false); // Get price in the main currency of the store. (USD, EUR, etc.)
             $productData['product_id']    = $maybeParent->getId();
             $productData['product_sku']   = $maybeParent->getData('sku');

--- a/Model/Cart.php
+++ b/Model/Cart.php
@@ -229,7 +229,7 @@ class Cart
                 }
             }
             // Required key/value pairs not in the payload by default.
-            $payload['API_KEY']= $this->apiConfig->getApiKey(ScopeInterface::SCOPE_STORES, $store->getId());
+            $payload['API_KEY']= $this->apiConfig->getPrivateApiKey(ScopeInterface::SCOPE_STORES, $store->getId());
             $payload['distinct_user_hash'] = $payload['CURRENT_PIXLEE_USER_ID'];
             $payload['ecommerce_platform'] = Pixlee::PLATFORM;
             $payload['ecommerce_platform_version'] = $this->productMetadata->getVersion();

--- a/Model/Cart.php
+++ b/Model/Cart.php
@@ -158,7 +158,7 @@ class Cart
 
             $productData['variant_id']    = $actualProduct->getId();
             $productData['variant_sku']   = $actualProduct->getSku();
-            $productData['quantity']      = round($product->getQtyOrdered());
+            $productData['quantity']      = round((float)$product->getQtyOrdered());
             $productData['price']         = $this->pricingHelper->currency($actualProduct->getPrice(), true, false); // Get price in the main currency of the store. (USD, EUR, etc.)
             $productData['product_id']    = $maybeParent->getId();
             $productData['product_sku']   = $maybeParent->getData('sku');

--- a/Model/Config/Api.php
+++ b/Model/Config/Api.php
@@ -102,18 +102,11 @@ class Api
      */
     public function getPrivateApiKey($scopeType, $scopeCode)
     {
-        $privateApiKey = $this->scopeConfig->getValue(
+        return $this->scopeConfig->getValue(
             self::PIXLEE_PRIVATE_API_KEY,
             $scopeType,
             $scopeCode
         );
-
-        /* Fallback can be removed after API requirements are updated */
-        if (empty($privateApiKey)) {
-            $privateApiKey = $this->getApiKey($scopeType, $scopeCode);
-        }
-
-        return $privateApiKey;
     }
 
     /**

--- a/Model/Config/Api.php
+++ b/Model/Config/Api.php
@@ -15,6 +15,7 @@ class Api
 {
     public const PIXLEE_ACTIVE = 'pixlee_pixlee/existing_customers/account_settings/active';
     public const PIXLEE_API_KEY = 'pixlee_pixlee/existing_customers/account_settings/api_key';
+    public const PIXLEE_PRIVATE_API_KEY = 'pixlee_pixlee/existing_customers/account_settings/private_api_key';
     public const PIXLEE_SECRET_KEY = 'pixlee_pixlee/existing_customers/account_settings/secret_key';
 
     /**
@@ -89,6 +90,41 @@ class Api
     {
         $this->configWriter->delete(
             self::PIXLEE_API_KEY,
+            $scopeType,
+            $scopeCode
+        );
+    }
+
+    /**
+     * @param int|null|string $scopeCode
+     * @param null|string $scopeType
+     * @return mixed
+     */
+    public function getPrivateApiKey($scopeType, $scopeCode)
+    {
+        $privateApiKey = $this->scopeConfig->getValue(
+            self::PIXLEE_PRIVATE_API_KEY,
+            $scopeType,
+            $scopeCode
+        );
+
+        /* Fallback can be removed after API requirements are updated */
+        if (empty($privateApiKey)) {
+            $privateApiKey = $this->getApiKey($scopeType, $scopeCode);
+        }
+
+        return $privateApiKey;
+    }
+
+    /**
+     * @param int|null|string $scopeCode
+     * @param null|string $scopeType
+     * @return void
+     */
+    public function deletePrivateApiKey($scopeType, $scopeCode)
+    {
+        $this->configWriter->delete(
+            self::PIXLEE_PRIVATE_API_KEY,
             $scopeType,
             $scopeCode
         );

--- a/Observer/CheckoutSuccessObserver.php
+++ b/Observer/CheckoutSuccessObserver.php
@@ -82,7 +82,7 @@ class CheckoutSuccessObserver implements ObserverInterface
                 /** @var OrderInterface $order */
                 foreach ($orders as $order) {
                     $conversionPayload = $this->pixleeCart->getConversionPayload($order);
-                    $this->analytics->sendEvent('checkoutSuccess', $conversionPayload);
+                    $this->analytics->sendEvent('checkoutSuccess', $conversionPayload, $order->getStore());
                 }
             }
         } catch (Exception $e) {
@@ -94,7 +94,7 @@ class CheckoutSuccessObserver implements ObserverInterface
      * @param Event $event
      * @return array|Collection
      */
-    protected function getOrders($event)
+    public function getOrders($event)
     {
         if ($order = $event->getOrder()) {
             return [$order];

--- a/Observer/CheckoutSuccessObserver.php
+++ b/Observer/CheckoutSuccessObserver.php
@@ -7,9 +7,10 @@
 namespace Pixlee\Pixlee\Observer;
 
 use Exception;
+use Magento\Framework\Event;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\ResourceModel\Order\Collection;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -41,10 +42,6 @@ class CheckoutSuccessObserver implements ObserverInterface
      */
     protected $storeManager;
     /**
-     * @var SerializerInterface
-     */
-    protected $serializer;
-    /**
      * @var AnalyticsServiceInterface
      */
     protected $analytics;
@@ -53,7 +50,6 @@ class CheckoutSuccessObserver implements ObserverInterface
      * @param Collection $orderCollection
      * @param PixleeLogger $logger
      * @param StoreManagerInterface $storeManager
-     * @param SerializerInterface $serializer
      * @param Cart $pixleeCart
      * @param Api $apiConfig
      * @param AnalyticsServiceInterface $analytics
@@ -62,7 +58,6 @@ class CheckoutSuccessObserver implements ObserverInterface
         Collection $orderCollection,
         PixleeLogger $logger,
         StoreManagerInterface $storeManager,
-        SerializerInterface $serializer,
         Cart $pixleeCart,
         Api $apiConfig,
         AnalyticsServiceInterface $analytics
@@ -70,7 +65,6 @@ class CheckoutSuccessObserver implements ObserverInterface
         $this->orderCollection = $orderCollection;
         $this->logger = $logger;
         $this->storeManager = $storeManager;
-        $this->serializer = $serializer;
         $this->pixleeCart = $pixleeCart;
         $this->apiConfig = $apiConfig;
         $this->analytics = $analytics;
@@ -83,25 +77,29 @@ class CheckoutSuccessObserver implements ObserverInterface
     public function execute(EventObserver $observer)
     {
         try {
-            $store = $this->storeManager->getStore();
-
-            if ($this->apiConfig->isActive(ScopeInterface::SCOPE_STORES, $store->getId())) {
-                $orderIds = $observer->getEvent()->getOrderIds();
-                if (!$orderIds || !is_array($orderIds)) {
-                    return;
-                }
-
-
-                $this->orderCollection->addFieldToFilter('entity_id', ['in' => $orderIds]);
-                foreach ($this->orderCollection as $order) {
-                    $cartData = $this->pixleeCart->extractCart($order);
-                    $payload = $this->pixleeCart->preparePayload($store, $cartData);
-                    $this->analytics->sendEvent('checkoutSuccess', $payload);
-                    $this->logger->addInfo('CheckoutSuccess ' . $this->serializer->serialize($payload));
+            if ($this->apiConfig->isActive(ScopeInterface::SCOPE_STORES, $this->storeManager->getStore()->getCode())) {
+                $orders = $this->getOrders($observer->getEvent());
+                /** @var OrderInterface $order */
+                foreach ($orders as $order) {
+                    $conversionPayload = $this->pixleeCart->getConversionPayload($order);
+                    $this->analytics->sendEvent('checkoutSuccess', $conversionPayload);
                 }
             }
         } catch (Exception $e) {
             $this->logger->error($e->getMessage(), ['exception' => $e]);
         }
+    }
+
+    /**
+     * @param Event $event
+     * @return array|Collection
+     */
+    protected function getOrders($event)
+    {
+        if ($order = $event->getOrder()) {
+            return [$order];
+        }
+
+        return $this->orderCollection->addFieldToFilter('entity_id', ['in' => $event->getOrderIds()]);
     }
 }

--- a/Observer/ValidateCredentialsObserver.php
+++ b/Observer/ValidateCredentialsObserver.php
@@ -62,6 +62,7 @@ class ValidateCredentialsObserver implements ObserverInterface
             if ($validated === false) {
                 $this->apiConfig->deleteActive($scope['scopeType'], $scope['scopeCode']);
                 $this->apiConfig->deleteApiKey($scope['scopeType'], $scope['scopeCode']);
+                $this->apiConfig->deletePrivateApiKey($scope['scopeType'], $scope['scopeCode']);
                 $this->apiConfig->deleteSecretKey($scope['scopeType'], $scope['scopeCode']);
 
                 throw new Exception('Invalid API key or secret.');

--- a/Observer/ValidateCredentialsObserver.php
+++ b/Observer/ValidateCredentialsObserver.php
@@ -61,11 +61,10 @@ class ValidateCredentialsObserver implements ObserverInterface
             $validated = $this->pixleeService->validateCredentials();
             if ($validated === false) {
                 $this->apiConfig->deleteActive($scope['scopeType'], $scope['scopeCode']);
-                $this->apiConfig->deleteApiKey($scope['scopeType'], $scope['scopeCode']);
                 $this->apiConfig->deletePrivateApiKey($scope['scopeType'], $scope['scopeCode']);
                 $this->apiConfig->deleteSecretKey($scope['scopeType'], $scope['scopeCode']);
 
-                throw new Exception('Invalid API key or secret.');
+                throw new Exception('Invalid Private API Key or Secret Key.');
             }
         }
     }

--- a/Service/Analytics.php
+++ b/Service/Analytics.php
@@ -115,7 +115,7 @@ class Analytics implements AnalyticsServiceInterface
                 }
             }
             // Required key/value pairs not in the payload by default.
-            $payload['API_KEY']= $this->apiConfig->getPrivateApiKey(ScopeInterface::SCOPE_STORES, $store->getCode());
+            $payload['API_KEY']= $this->apiConfig->getApiKey(ScopeInterface::SCOPE_STORES, $store->getCode());
             $payload['distinct_user_hash'] = $payload['CURRENT_PIXLEE_USER_ID'];
             $payload['ecommerce_platform'] = Pixlee::PLATFORM;
             $payload['ecommerce_platform_version'] = $this->productMetadata->getVersion();

--- a/Service/Distillery.php
+++ b/Service/Distillery.php
@@ -92,7 +92,7 @@ class Distillery implements PixleeServiceInterface
     {
         $path = 'v1/notifyExportStatus';
         $payload = [
-            'api_key' => $this->apiConfig->getApiKey($this->scopeType, $this->scopeCode),
+            'api_key' => $this->apiConfig->getPrivateApiKey($this->scopeType, $this->scopeCode),
             'status' => $status,
             'job_id' => $jobId,
             'num_products' => $numProducts,
@@ -196,7 +196,7 @@ class Distillery implements PixleeServiceInterface
      */
     protected function getRequiredQueryString()
     {
-        return '?api_key=' . $this->apiConfig->getApiKey($this->scopeType, $this->scopeCode);
+        return '?api_key=' . $this->apiConfig->getPrivateApiKey($this->scopeType, $this->scopeCode);
     }
 
     /**

--- a/Service/Distillery.php
+++ b/Service/Distillery.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Pixlee\Pixlee\Service;
 
+use Exception;
 use Magento\Framework\HTTP\Client\Curl;
 use Magento\Framework\Serialize\SerializerInterface;
 use Pixlee\Pixlee\Api\PixleeServiceInterface;
@@ -90,16 +91,20 @@ class Distillery implements PixleeServiceInterface
      */
     public function notifyExportStatus($status, $jobId, $numProducts)
     {
-        $path = 'v1/notifyExportStatus';
-        $payload = [
-            'api_key' => $this->apiConfig->getPrivateApiKey($this->scopeType, $this->scopeCode),
-            'status' => $status,
-            'job_id' => $jobId,
-            'num_products' => $numProducts,
-            'platform' => Pixlee::PLATFORM
-        ];
+        try {
+            $path = 'v1/notifyExportStatus';
+            $payload = [
+                'api_key' => $this->apiConfig->getPrivateApiKey($this->scopeType, $this->scopeCode),
+                'status' => $status,
+                'job_id' => $jobId,
+                'num_products' => $numProducts,
+                'platform' => Pixlee::PLATFORM
+            ];
 
-        $this->post($path, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            $this->post($path, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pixlee/magento2",
     "description": "Social commerce platform to collect, curate, and display user-generated content to enhance your Magento store",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "type": "magento2-module",
     "license": [
         "OSL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pixlee/magento2",
     "description": "Social commerce platform to collect, curate, and display user-generated content to enhance your Magento store",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "type": "magento2-module",
     "license": [
         "OSL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,6 +35,13 @@
                         </depends>
 	                </field>
 
+                    <field id="private_api_key" translate="label" type="text" sortOrder="20"  showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Private API Key</label>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
+                    </field>
+
 					<!-- Secret Key -->
 					<field id="secret_key" translate="label" type="text" sortOrder="30"  showInDefault="1" showInWebsite="1" showInStore="0">
 	                    <label>Secret Key</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,8 +35,9 @@
                         </depends>
 	                </field>
 
-                    <field id="private_api_key" translate="label" type="text" sortOrder="20"  showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="private_api_key" translate="label" type="obscure" sortOrder="20"  showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Private API Key</label>
+                        <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                         <depends>
                             <field id="active">1</field>
                         </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,11 @@
             <products>
                 <export_enabled>1</export_enabled>
             </products>
+            <existing_customers>
+                <account_settings>
+                    <private_api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+                </account_settings>
+            </existing_customers>
         </pixlee_pixlee>
     </default>
 </config>


### PR DESCRIPTION
- #84 - For some reason the function shows it should return an int but it returns a string. Fixed by coercing to int.
- #85 - Did a refactor of the conversion observer logic to get Item data from the visible order items only returning variant data for Configurable products. This eliminates the need to load products. It also supports all product types including Bundle and Grouped. For grouped products, each simple is visible and sent as individual products. For bundles, the bundle product is visible not the simples. The item sku is a combination of all the simple skus so I used the item->getProduct()->getSku() instead of item->getProductSku() which is only the bundle product sku not the simples. Also refactored AddToCart analytics to match Conversion.
- TSD-321 - Add Private API Key