### PR TITLE
Remove final per coding standards

### DIFF
--- a/Test/Unit/Service/AnalyticsResponseFixtures.php
+++ b/Test/Unit/Service/AnalyticsResponseFixtures.php
@@ -14,7 +14,7 @@ namespace Pixlee\Pixlee\Test\Unit\Service;
  *
  * Replace or extend these fixtures with captured production responses when available.
  */
-final class AnalyticsResponseFixtures
+class AnalyticsResponseFixtures
 {
     public const HTTP_OK = 200;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only fixture change with no production or security impact.
> 
> **Overview**
> Aligns **AnalyticsResponseFixtures** with project coding standards by dropping the **`final`** keyword on the test fixture class in `Test/Unit/Service/AnalyticsResponseFixtures.php`. Constants and docblocks are unchanged; only extensibility of the class is affected for unit tests around inbound-analytics response shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada875decb45821f77b0ecd8f23ee171bf5663f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->